### PR TITLE
Fix duplicate check

### DIFF
--- a/src/tasks/formatQueryTokens.ts
+++ b/src/tasks/formatQueryTokens.ts
@@ -72,7 +72,10 @@ const setupFormatQueryTokens: () => void = () => {
             ? -1
             : 1,
         )
-        .filter((token, index) => index === tokens.indexOf(token));
+        .filter(
+          (token, index) =>
+            index === tokens.findIndex((t) => token.address === t.address),
+        );
       const outputStrings = tokens
         .map((token) => formatToken(token, hre.network.name))
         .filter((output) => output !== null);


### PR DESCRIPTION
Fixes #6.

### Test plan

Create a file `test.txt` with content `\xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee`.

Run:
```
$ npx hardhat formatQueryTokens --input-file test.txt
Token without address or decimals at address 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee, see block explorer at  == no block explorer available for network hardhat == 
```

See only a single warning in output.