### PR TITLE
Add hyphen to valid characters

### DIFF
--- a/src/tasks/formatQueryTokens.ts
+++ b/src/tasks/formatQueryTokens.ts
@@ -29,7 +29,7 @@ function formatToken(token: TokenDetails, network: string): string | null {
     );
     return null;
   }
-  if (!/^[a-zA-Z0-9]*$/.exec(token.symbol)) {
+  if (!/^[-a-zA-Z0-9]*$/.exec(token.symbol)) {
     console.warn(
       `Token at address ${token.address} contains invalid characters in its symbol: ${token.symbol}`,
     );


### PR DESCRIPTION
Adds hypen to valid characters to help mitigate #7.

### Test plan

Create file `test.txt` containing `\xc5bddf9843308380375a611c18b50fb9341f502a`.
Run:
```
$ npx hardhat formatQueryTokens --input-file test.txt --network mainnet
('yveCRV-DAO', 18, decode('c5bddf9843308380375a611c18b50fb9341f502a', 'hex')),
```