### PR TITLE
Add support for tokens with bytes32 symbol

### DIFF
--- a/src/ts/erc20.ts
+++ b/src/ts/erc20.ts
@@ -1,7 +1,7 @@
 import "@nomiclabs/hardhat-ethers";
 
 import ERC20 from "@openzeppelin/contracts/build/contracts/ERC20.json";
-import { BigNumber, Contract } from "ethers";
+import { BigNumber, Bytes, BytesLike, Contract, utils } from "ethers";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
 export interface TokenDetails {
@@ -11,6 +11,21 @@ export interface TokenDetails {
   address: string;
 }
 
+function stripZerosRight(bytes: BytesLike): Bytes {
+  return utils.stripZeros(utils.arrayify(bytes).reverse()).reverse();
+}
+
+const ERC20_BYTES32_SYMBOL_ABI = `[{
+  "inputs": [],
+  "name": "symbol",
+  "outputs": [{
+      "name": "",
+      "type": "bytes32"
+  }],
+  "stateMutability": "view",
+  "type": "function"
+}]`;
+
 export async function tokenDetails(
   address: string,
   hre: HardhatRuntimeEnvironment,
@@ -19,7 +34,16 @@ export async function tokenDetails(
   const [symbol, decimals] = await Promise.all([
     contract
       .symbol()
-      .then((s: unknown) => (typeof s !== "string" ? null : s))
+      .catch(async () => {
+        const bytes32Contract = new Contract(
+          address,
+          ERC20_BYTES32_SYMBOL_ABI,
+          hre.ethers.provider,
+        );
+        return utils.toUtf8String(
+          stripZerosRight(await bytes32Contract.symbol()),
+        );
+      })
       .catch(() => null),
     contract
       .decimals()


### PR DESCRIPTION
Some tokens (notably MKR) don't have a `string` symbol but a `bytes32` symbol. This PR adds support for these tokens. 

Closes #10.

### Test plan

Create file `test.txt` containing `\x431ad2ff6a9c365805ebad47ee021148d6f7dbe0\x9f8F72aA9304c8B593d555F12eF6589cC3A579A2`.
Run:
```
$ npx hardhat formatQueryTokens --input-file test.txt --network mainnet
('DF', 18, decode('431ad2ff6a9c365805ebad47ee021148d6f7dbe0', 'hex')),
('MKR', 18, decode('9f8f72aa9304c8b593d555f12ef6589cc3a579a2', 'hex')),
```