### PR TITLE
Add a link to dashboard in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GPv2 Dune tools
 
-A repository collecting the tools we used to build the Dune dashboards for GPv2.
+A repository collecting the tools we used to build the [Dune dashboards for GPv2](https://duneanalytics.com/gnosis.protocol/Gnosis-Protocol-V2).
 
 ## Testing
 


### PR DESCRIPTION
Just a tiny PR that adds a link to the GPv2 Dune dashboard directly to make it more easily discoverable from the repo.