### PR TITLE
add mergify config

### DIFF
--- a/.mergify.yaml
+++ b/.mergify.yaml
@@ -1,0 +1,23 @@
+
+pull_request_rules:
+  - name: Merge approved and green PRs with `merge when green` label
+    conditions:
+      - "#approved-reviews-by>=1"
+      - status-success~=^test \([0-9]+\.x, ubuntu-latest\)$
+      - base=main
+      - label=merge when green
+    actions:
+      merge:
+        method: squash
+        strict: smart+fasttrack
+        commit_message: title+body
+  - name: Automatic merge for Dependabot pull requests
+    conditions:
+      - author~=^dependabot(|-preview)\[bot\]$
+      - status-success~=^test \([0-9]+\.x, ubuntu-latest\)$
+      - base=main
+    actions:
+      merge:
+        method: squash
+        strict: smart+fasttrack
+        commit_message: title+body

--- a/.mergify.yaml
+++ b/.mergify.yaml
@@ -1,4 +1,3 @@
-
 pull_request_rules:
   - name: Merge approved and green PRs with `merge when green` label
     conditions:


### PR DESCRIPTION
Adding Mergify configuration file with two rules. 

1. Allow merge when green PR label to merge when green
2. Automatically merge all passing dependabot PRs.

Not sure how to test this... I guess we need to wait a week for dependabot?